### PR TITLE
[FEAT] 구글로그인 후 서버에서 AT, RT 받아오고 만료되면 갱신되는 로직 구현

### DIFF
--- a/app/src/main/java/org/sopt/and/data/api/AuthApi.kt
+++ b/app/src/main/java/org/sopt/and/data/api/AuthApi.kt
@@ -1,14 +1,30 @@
 package org.sopt.and.data.api
 
+import org.sopt.and.data.model.request.GoogleLoginRequest
+import org.sopt.and.data.model.request.RefreshRequest
 import org.sopt.and.utils.base.NullableBaseResponse
 import org.sopt.and.data.model.request.UserLoginRequestDto
 import org.sopt.and.data.model.request.UserRegisterRequestDto
+import org.sopt.and.data.model.response.GoogleLoginResponse
+import org.sopt.and.data.model.response.RefreshResponse
 import org.sopt.and.data.model.response.UserLoginResponse
 import org.sopt.and.data.model.response.UserRegisterResponse
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST
 
 interface AuthApi {
+    // 구글 로그인 API
+    @POST("/api/v1/auth/login")
+    suspend fun postLogin(
+        @Body body: GoogleLoginRequest
+    ) : GoogleLoginResponse
+
+    // 액세스 토큰 재발급 API
+    @POST("/api/v1/auth/reissue")
+    suspend fun postRefresh(
+        @Body refreshRequest: RefreshRequest
+    ) : Response<RefreshResponse>
 
     @POST("/user")
     suspend fun registerUser(

--- a/app/src/main/java/org/sopt/and/data/api/AuthApi.kt
+++ b/app/src/main/java/org/sopt/and/data/api/AuthApi.kt
@@ -20,12 +20,6 @@ interface AuthApi {
         @Body body: GoogleLoginRequest
     ) : GoogleLoginResponse
 
-    // 액세스 토큰 재발급 API
-    @POST("/api/v1/auth/reissue")
-    suspend fun postRefresh(
-        @Body refreshRequest: RefreshRequest
-    ) : Response<RefreshResponse>
-
     @POST("/user")
     suspend fun registerUser(
         @Body body: UserRegisterRequestDto

--- a/app/src/main/java/org/sopt/and/data/api/ReissueTokenApi.kt
+++ b/app/src/main/java/org/sopt/and/data/api/ReissueTokenApi.kt
@@ -1,0 +1,15 @@
+package org.sopt.and.data.api
+
+import org.sopt.and.data.model.request.RefreshRequest
+import org.sopt.and.data.model.response.RefreshResponse
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface ReissueTokenApi {
+    // 액세스 토큰 재발급 API
+    @POST("/api/v1/auth/reissue")
+    suspend fun postRefresh(
+        @Body refreshRequest: RefreshRequest
+    ) : Response<RefreshResponse>
+}

--- a/app/src/main/java/org/sopt/and/data/model/request/GoogleLoginRequest.kt
+++ b/app/src/main/java/org/sopt/and/data/model/request/GoogleLoginRequest.kt
@@ -1,0 +1,10 @@
+package org.sopt.and.data.model.request
+
+import org.sopt.and.utils.SocialType
+
+data class GoogleLoginRequest(
+    //@SerializedName("socialType")
+    val socialType: SocialType,
+    //@SerializedName("idToken")
+    val idToken: String,
+)

--- a/app/src/main/java/org/sopt/and/data/model/request/RefreshRequest.kt
+++ b/app/src/main/java/org/sopt/and/data/model/request/RefreshRequest.kt
@@ -1,0 +1,6 @@
+package org.sopt.and.data.model.request
+
+data class RefreshRequest(
+    //@SerializedName("refreshToken")
+    val refreshToken: String,
+)

--- a/app/src/main/java/org/sopt/and/data/model/response/GoogleLoginResponse.kt
+++ b/app/src/main/java/org/sopt/and/data/model/response/GoogleLoginResponse.kt
@@ -1,0 +1,8 @@
+package org.sopt.and.data.model.response
+
+data class GoogleLoginResponse(
+    //@SerializedName("accessToken")
+    val accessToken: String,
+    //@SerializedName("refreshToken")
+    val refreshToken: String,
+)

--- a/app/src/main/java/org/sopt/and/data/model/response/RefreshResponse.kt
+++ b/app/src/main/java/org/sopt/and/data/model/response/RefreshResponse.kt
@@ -1,0 +1,12 @@
+package org.sopt.and.data.model.response
+
+data class RefreshResponse(
+    //@SerializedName("accessToken")
+    val accessToken: String,
+    //@SerializedName("refreshToken")
+    val refreshToken: String,
+) {
+    // 리프레시 토큰 -> 새로운 토큰으로 갱신하기 위해 변환하는 함수
+    fun refreshResponseToGoogleLogin() =
+        GoogleLoginResponse(accessToken = accessToken, refreshToken = refreshToken)
+}

--- a/app/src/main/java/org/sopt/and/data/model/response/RefreshResponse.kt
+++ b/app/src/main/java/org/sopt/and/data/model/response/RefreshResponse.kt
@@ -1,5 +1,7 @@
 package org.sopt.and.data.model.response
 
+import org.sopt.and.domain.model.AuthToken
+
 data class RefreshResponse(
     //@SerializedName("accessToken")
     val accessToken: String,
@@ -7,6 +9,9 @@ data class RefreshResponse(
     val refreshToken: String,
 ) {
     // 리프레시 토큰 -> 새로운 토큰으로 갱신하기 위해 변환하는 함수
-    fun refreshResponseToGoogleLogin() =
-        GoogleLoginResponse(accessToken = accessToken, refreshToken = refreshToken)
+    fun refreshResponseToAuthToken() =
+        AuthToken(
+            accessToken = accessToken,
+            refreshToken = refreshToken
+        )
 }

--- a/app/src/main/java/org/sopt/and/data/remote/datasource/local/LoadHomeImageLocalDataSource.kt
+++ b/app/src/main/java/org/sopt/and/data/remote/datasource/local/LoadHomeImageLocalDataSource.kt
@@ -6,7 +6,7 @@ import org.sopt.and.presentation.data.HomeData
 import org.sopt.and.presentation.type.MovieType
 import javax.inject.Inject
 
-class LocalHomeImageDataSource @Inject constructor() {
+class LoadHomeImageLocalDataSource @Inject constructor() {
     private val categories = persistentListOf(
         MovieType.NEW_CLASSIC,
         MovieType.DRAMA,

--- a/app/src/main/java/org/sopt/and/data/remote/datasource/local/TokenLocalDataSource.kt
+++ b/app/src/main/java/org/sopt/and/data/remote/datasource/local/TokenLocalDataSource.kt
@@ -1,0 +1,66 @@
+package org.sopt.and.data.remote.datasource.local
+
+import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class TokenLocalDataSource @Inject constructor(
+    @ApplicationContext applicationContext: Context,
+    private val dispatchersIO: CoroutineDispatcher,
+) {
+    var masterKey = MasterKey.Builder(applicationContext, MasterKey.DEFAULT_MASTER_KEY_ALIAS)
+        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+        .build()
+
+    // 키와 값을 암호화하여 저장하는 SharedPreferences 구현체
+    var sharedPreferences = EncryptedSharedPreferences.create(
+        applicationContext,
+        SHARED_PREF_FILENAME,
+        masterKey,
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+    )
+
+    suspend fun saveAccessToken(
+        accessToken: String,
+    ) = withContext(dispatchersIO) {
+        with(sharedPreferences.edit()) {
+            putString(SHARED_PREF_KEY, accessToken)
+            apply() // 변경 사항을 비동기적으로 저장
+        }
+    }
+
+    suspend fun saveRefreshToken(
+        refreshToken: String,
+    ) = withContext(dispatchersIO) {
+        with(sharedPreferences.edit()) {
+            putString(SHARED_PREF_REFRESH_KEY, refreshToken)
+            apply()
+        }
+    }
+
+    suspend fun getAccessToken(): String? = withContext(dispatchersIO) {
+        sharedPreferences.getString(SHARED_PREF_KEY, null)
+    }
+
+    suspend fun getRefreshToken(): String? = withContext(dispatchersIO) {
+        sharedPreferences.getString(SHARED_PREF_REFRESH_KEY, null)
+    }
+
+    suspend fun removeRefreshToken() = withContext(dispatchersIO) {
+        with(sharedPreferences.edit()) {
+            remove(SHARED_PREF_REFRESH_KEY)
+            apply()
+        }
+    }
+
+    companion object {
+        private const val SHARED_PREF_FILENAME = "token"
+        private const val SHARED_PREF_KEY = "accessToken"
+        private const val SHARED_PREF_REFRESH_KEY = "refreshToken"
+    }
+}

--- a/app/src/main/java/org/sopt/and/data/remote/datasource/local/TokenLocalDataSource.kt
+++ b/app/src/main/java/org/sopt/and/data/remote/datasource/local/TokenLocalDataSource.kt
@@ -51,6 +51,13 @@ class TokenLocalDataSource @Inject constructor(
         sharedPreferences.getString(SHARED_PREF_REFRESH_KEY, null)
     }
 
+    suspend fun removeAccessToken() = withContext(dispatchersIO) {
+        with(sharedPreferences.edit()) {
+            remove(SHARED_PREF_KEY)
+            apply()
+        }
+    }
+
     suspend fun removeRefreshToken() = withContext(dispatchersIO) {
         with(sharedPreferences.edit()) {
             remove(SHARED_PREF_REFRESH_KEY)

--- a/app/src/main/java/org/sopt/and/data/remote/datasource/remote/AuthDataSource.kt
+++ b/app/src/main/java/org/sopt/and/data/remote/datasource/remote/AuthDataSource.kt
@@ -20,10 +20,6 @@ class AuthDataSource @Inject constructor(
     suspend fun postLogin(googleLoginRequest: GoogleLoginRequest): GoogleLoginResponse {
         return authApi.postLogin(googleLoginRequest)
     }
-    // refresh Token
-    suspend fun postRefresh(refreshRequest: RefreshRequest): Response<RefreshResponse> {
-        return authApi.postRefresh(refreshRequest)
-    }
 
     suspend fun registerUser(userRegisterRequestDto: UserRegisterRequestDto): NullableBaseResponse<UserRegisterResponse> {
         return authApi.registerUser(userRegisterRequestDto)

--- a/app/src/main/java/org/sopt/and/data/remote/datasource/remote/AuthDataSource.kt
+++ b/app/src/main/java/org/sopt/and/data/remote/datasource/remote/AuthDataSource.kt
@@ -1,16 +1,30 @@
 package org.sopt.and.data.remote.datasource.remote
 
 import org.sopt.and.data.api.AuthApi
+import org.sopt.and.data.model.request.GoogleLoginRequest
+import org.sopt.and.data.model.request.RefreshRequest
 import org.sopt.and.utils.base.NullableBaseResponse
 import org.sopt.and.data.model.request.UserLoginRequestDto
 import org.sopt.and.data.model.request.UserRegisterRequestDto
+import org.sopt.and.data.model.response.GoogleLoginResponse
+import org.sopt.and.data.model.response.RefreshResponse
 import org.sopt.and.data.model.response.UserLoginResponse
 import org.sopt.and.data.model.response.UserRegisterResponse
+import retrofit2.Response
 import javax.inject.Inject
 
 class AuthDataSource @Inject constructor(
     private val authApi: AuthApi
 ) {
+    // 구글 로그인
+    suspend fun postLogin(googleLoginRequest: GoogleLoginRequest): GoogleLoginResponse {
+        return authApi.postLogin(googleLoginRequest)
+    }
+    // refresh Token
+    suspend fun postRefresh(refreshRequest: RefreshRequest): Response<RefreshResponse> {
+        return authApi.postRefresh(refreshRequest)
+    }
+
     suspend fun registerUser(userRegisterRequestDto: UserRegisterRequestDto): NullableBaseResponse<UserRegisterResponse> {
         return authApi.registerUser(userRegisterRequestDto)
     }
@@ -18,4 +32,5 @@ class AuthDataSource @Inject constructor(
     suspend fun loginUser(userLoginRequestDto: UserLoginRequestDto): NullableBaseResponse<UserLoginResponse> {
         return authApi.loginUser(userLoginRequestDto)
     }
+
 }

--- a/app/src/main/java/org/sopt/and/data/remote/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/org/sopt/and/data/remote/repository/AuthRepositoryImpl.kt
@@ -24,12 +24,13 @@ class AuthRepositoryImpl @Inject constructor(
     override suspend fun postLogin(
         socialType: SocialType,
         idToken: String
-    ): AuthToken {
-        val googleLoginResponse = authDataSource.postLogin(GoogleLoginRequest(socialType, idToken))
-        // tokenLocalDataSource.saveAccessToken(googleLoginResponse.accessToken)
-        // tokenLocalDataSource.saveAccessToken(googleLoginResponse.refreshToken)
-        // 여기서 이렇게 서버에서 온 토큰을 직접 저장해야하는지 모르겠습니다..
-        return AuthToken(googleLoginResponse.accessToken, googleLoginResponse.refreshToken)
+    ): Result<Unit> {
+        return runCatching {
+            val googleLoginResponse =
+                authDataSource.postLogin(GoogleLoginRequest(socialType, idToken))
+            tokenLocalDataSource.saveAccessToken(googleLoginResponse.accessToken)
+            tokenLocalDataSource.saveRefreshToken(googleLoginResponse.refreshToken)
+        }
     }
 
     override suspend fun registerUser(
@@ -41,6 +42,7 @@ class AuthRepositoryImpl @Inject constructor(
             AuthMapper.mapperToUserIdEntity(response.result)
         }
     }
+
     override suspend fun loginUser(loginUserEntity: LoginUserEntity): Result<UserTokenEntity> {
         return runCatching {
             val requestDto = AuthMapper.mapperToUserLoginRequestDto(loginUserEntity)
@@ -51,5 +53,5 @@ class AuthRepositoryImpl @Inject constructor(
             tokenEntity
         }
     }
-
 }
+

--- a/app/src/main/java/org/sopt/and/data/remote/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/org/sopt/and/data/remote/repository/AuthRepositoryImpl.kt
@@ -1,12 +1,15 @@
 package org.sopt.and.data.remote.repository
 
 import org.sopt.and.data.mapper.AuthMapper
+import org.sopt.and.data.model.request.GoogleLoginRequest
+import org.sopt.and.data.model.request.RefreshRequest
 import org.sopt.and.data.remote.datasource.remote.AuthDataSource
 import org.sopt.and.domain.model.auth.LoginUserEntity
 import org.sopt.and.domain.model.auth.RegisterUserEntity
 import org.sopt.and.domain.model.auth.UserIdEntity
 import org.sopt.and.domain.model.auth.UserTokenEntity
 import org.sopt.and.domain.repository.AuthRepository
+import org.sopt.and.utils.SocialType
 import org.sopt.and.utils.TokenManager
 import javax.inject.Inject
 
@@ -14,6 +17,23 @@ class AuthRepositoryImpl @Inject constructor(
     private val authDataSource: AuthDataSource,
     private val tokenManager: TokenManager
 ) : AuthRepository {
+    // 구글 로그인
+    override suspend fun postLogin(
+        socialType: SocialType,
+        idToken: String
+    ): Result<Unit> {
+        return runCatching {
+            val googleLoginResponse = authDataSource.postLogin(GoogleLoginRequest(socialType, idToken))
+            googleLoginResponse.accessToken.let {}
+        }
+    }
+
+    // refresh Token
+    override suspend fun postRefresh(refreshToken: String): Result<Unit> {
+        return runCatching {
+            val refreshResponse = authDataSource.postRefresh(RefreshRequest(refreshToken))
+        }
+    }
 
     override suspend fun registerUser(
         userEntity: RegisterUserEntity

--- a/app/src/main/java/org/sopt/and/data/remote/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/org/sopt/and/data/remote/repository/AuthRepositoryImpl.kt
@@ -3,7 +3,9 @@ package org.sopt.and.data.remote.repository
 import org.sopt.and.data.mapper.AuthMapper
 import org.sopt.and.data.model.request.GoogleLoginRequest
 import org.sopt.and.data.model.request.RefreshRequest
+import org.sopt.and.data.remote.datasource.local.TokenLocalDataSource
 import org.sopt.and.data.remote.datasource.remote.AuthDataSource
+import org.sopt.and.domain.model.AuthToken
 import org.sopt.and.domain.model.auth.LoginUserEntity
 import org.sopt.and.domain.model.auth.RegisterUserEntity
 import org.sopt.and.domain.model.auth.UserIdEntity
@@ -15,24 +17,19 @@ import javax.inject.Inject
 
 class AuthRepositoryImpl @Inject constructor(
     private val authDataSource: AuthDataSource,
-    private val tokenManager: TokenManager
+    private val tokenManager: TokenManager,
+    private val tokenLocalDataSource: TokenLocalDataSource // 토큰 저장소
 ) : AuthRepository {
     // 구글 로그인
     override suspend fun postLogin(
         socialType: SocialType,
         idToken: String
-    ): Result<Unit> {
-        return runCatching {
-            val googleLoginResponse = authDataSource.postLogin(GoogleLoginRequest(socialType, idToken))
-            googleLoginResponse.accessToken.let {}
-        }
-    }
-
-    // refresh Token
-    override suspend fun postRefresh(refreshToken: String): Result<Unit> {
-        return runCatching {
-            val refreshResponse = authDataSource.postRefresh(RefreshRequest(refreshToken))
-        }
+    ): AuthToken {
+        val googleLoginResponse = authDataSource.postLogin(GoogleLoginRequest(socialType, idToken))
+        // tokenLocalDataSource.saveAccessToken(googleLoginResponse.accessToken)
+        // tokenLocalDataSource.saveAccessToken(googleLoginResponse.refreshToken)
+        // 여기서 이렇게 서버에서 온 토큰을 직접 저장해야하는지 모르겠습니다..
+        return AuthToken(googleLoginResponse.accessToken, googleLoginResponse.refreshToken)
     }
 
     override suspend fun registerUser(

--- a/app/src/main/java/org/sopt/and/data/remote/repository/AuthTokenRepositoryImpl.kt
+++ b/app/src/main/java/org/sopt/and/data/remote/repository/AuthTokenRepositoryImpl.kt
@@ -24,6 +24,10 @@ class AuthTokenRepositoryImpl @Inject constructor(
         return runBlocking { tokenLocalDataSource.getRefreshToken() }
     }
 
+    override suspend fun removeAccessToken() {
+        tokenLocalDataSource.removeAccessToken()
+    }
+
     override suspend fun removeRefreshToken() {
         tokenLocalDataSource.removeRefreshToken()
     }

--- a/app/src/main/java/org/sopt/and/data/remote/repository/AuthTokenRepositoryImpl.kt
+++ b/app/src/main/java/org/sopt/and/data/remote/repository/AuthTokenRepositoryImpl.kt
@@ -1,0 +1,30 @@
+package org.sopt.and.data.remote.repository
+
+import kotlinx.coroutines.runBlocking
+import org.sopt.and.data.remote.datasource.local.TokenLocalDataSource
+import org.sopt.and.domain.repository.AuthTokenRepository
+import javax.inject.Inject
+
+class AuthTokenRepositoryImpl @Inject constructor(
+    private val tokenLocalDataSource: TokenLocalDataSource,
+): AuthTokenRepository {
+    override suspend fun saveAccessToken(token: String) {
+        tokenLocalDataSource.saveAccessToken(token)
+    }
+
+    override suspend fun saveRefreshToken(token: String) {
+        tokenLocalDataSource.saveRefreshToken(token)
+    }
+
+    override suspend fun getAccessToken(): String? {
+        return runBlocking { tokenLocalDataSource.getAccessToken() }
+    }
+
+    override suspend fun getRefreshToken(): String? {
+        return runBlocking { tokenLocalDataSource.getRefreshToken() }
+    }
+
+    override suspend fun removeRefreshToken() {
+        tokenLocalDataSource.removeRefreshToken()
+    }
+}

--- a/app/src/main/java/org/sopt/and/data/remote/repository/GoogleTokenRepositoryImpl.kt
+++ b/app/src/main/java/org/sopt/and/data/remote/repository/GoogleTokenRepositoryImpl.kt
@@ -2,12 +2,12 @@ package org.sopt.and.data.remote.repository
 
 import androidx.credentials.Credential
 import org.sopt.and.data.remote.datasource.remote.TokenRemoteDataSource
-import org.sopt.and.domain.repository.TokenRepository
+import org.sopt.and.domain.repository.GoogleTokenRepository
 import javax.inject.Inject
 
-class GoogleSignInRepositoryImpl @Inject constructor(
+class GoogleTokenRepositoryImpl @Inject constructor(
     private val googleSignInDataSource: TokenRemoteDataSource
-): TokenRepository {
+): GoogleTokenRepository {
     override suspend fun signIn(): Result<Credential> =
         googleSignInDataSource.signIn()
 }

--- a/app/src/main/java/org/sopt/and/data/remote/repository/LocalHomeImageRepositoryImpl.kt
+++ b/app/src/main/java/org/sopt/and/data/remote/repository/LocalHomeImageRepositoryImpl.kt
@@ -1,12 +1,12 @@
 package org.sopt.and.data.remote.repository
 
-import org.sopt.and.data.remote.datasource.local.LocalHomeImageDataSource
+import org.sopt.and.data.remote.datasource.local.LoadHomeImageLocalDataSource
 import org.sopt.and.domain.repository.LocalHomeImageRepository
 import org.sopt.and.presentation.data.HomeData
 import javax.inject.Inject
 
 class LocalHomeImageRepositoryImpl @Inject constructor(
-    private val localHomeImageDataSource: LocalHomeImageDataSource
+    private val localHomeImageDataSource: LoadHomeImageLocalDataSource
 ) : LocalHomeImageRepository {
     override suspend fun getHomeData(): Result<HomeData> {
         return localHomeImageDataSource.getHomeData()

--- a/app/src/main/java/org/sopt/and/di/CoroutineModule.kt
+++ b/app/src/main/java/org/sopt/and/di/CoroutineModule.kt
@@ -1,0 +1,20 @@
+package org.sopt.and.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.Dispatchers
+import javax.inject.Qualifier
+
+@Module
+@InstallIn(SingletonComponent::class)
+object CoroutineModule {
+    @Qualifier
+    @Retention(AnnotationRetention.RUNTIME)
+    annotation class IoDispatcher
+
+    @IoDispatcher // -> Qualifier
+    @Provides
+    fun providesIoDispatcher() = Dispatchers.IO
+}

--- a/app/src/main/java/org/sopt/and/di/api/ApiModule.kt
+++ b/app/src/main/java/org/sopt/and/di/api/ApiModule.kt
@@ -5,8 +5,11 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import org.sopt.and.data.api.AuthApi
+import org.sopt.and.data.api.ReissueTokenApi
 import org.sopt.and.data.api.UserApi
 import org.sopt.and.di.network.NetworkModule
+import org.sopt.and.utils.qualifier.AuthNotRequired
+import org.sopt.and.utils.qualifier.AuthRequired
 import retrofit2.Retrofit
 import javax.inject.Singleton
 
@@ -17,12 +20,19 @@ object ApiModule {
     @Provides
     @Singleton
     fun provideAuthApi(
-        @NetworkModule.MainServer retrofit: Retrofit
+        @AuthRequired retrofit: Retrofit
     ) : AuthApi = retrofit.create(AuthApi::class.java)
+
+    @AuthRequired
+    @Provides
+    @Singleton
+    fun provideReissueTokenApi(
+        @AuthNotRequired retrofit: Retrofit
+    ) : ReissueTokenApi = retrofit.create(ReissueTokenApi::class.java)
 
     @Provides
     @Singleton
     fun provideUserApi(
-        @NetworkModule.MainServer retrofit: Retrofit
+        @AuthNotRequired retrofit: Retrofit
     ) : UserApi = retrofit.create(UserApi::class.java)
 }

--- a/app/src/main/java/org/sopt/and/di/network/AuthAuthenticator.kt
+++ b/app/src/main/java/org/sopt/and/di/network/AuthAuthenticator.kt
@@ -1,0 +1,90 @@
+package org.sopt.and.di.network
+
+import android.content.Context
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import okhttp3.Authenticator
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+import org.sopt.and.data.api.AuthApi
+import org.sopt.and.data.model.request.RefreshRequest
+import org.sopt.and.data.remote.datasource.local.TokenLocalDataSource
+import timber.log.Timber
+import javax.inject.Inject
+
+class AuthAuthenticator @Inject constructor(
+    private val context: Context,
+    private val tokenLocalDataSource: TokenLocalDataSource,
+    private val authApi: AuthApi,
+    private val maxRetry: Int = 5,
+) : Authenticator {
+    private val mutex = Mutex()
+
+    // OkHttp에서 HTTP 요청이 401 상태 코드를 반환하면 호출됨
+    // 액세스 토큰이 만료되면 자동으로 액세스 토큰을 재발급 요청 하는 함수
+    override fun authenticate(route: Route?, response: Response): Request? = runBlocking {
+        mutex.withLock {
+            Timber.e("HTTP 401 response : $response")
+            Timber.e("토큰 재발급 요청 시도")
+            // 지정 최대 시도 횟수를 초과하면 로그인 화면으로 이동
+            if (response.responseCount() > maxRetry) {
+                tokenLocalDataSource.removeRefreshToken() // RefreshToken 삭제
+                goToLoginActivity()
+                return@withLock null
+            }
+
+            // 현재 리프레시 토큰 가져오기
+            val currentRefreshToken = tokenLocalDataSource.getRefreshToken() ?: ""
+
+            // 토큰 재발급 API 호출
+            val newResponse = runCatching {
+                authApi.postRefresh(RefreshRequest(currentRefreshToken))
+            }.onSuccess {
+                if (!it.isSuccessful) {
+                    Timber.e("Refresh API HTTP Exception : $it")
+                    tokenLocalDataSource.removeRefreshToken() // RefreshToken 삭제
+                    goToLoginActivity() // 로그인 화면으로 이동
+                    return@withLock null
+                }
+            }.onFailure {
+                Timber.e("Refresh 재발급 API 호출 에러 : ${it.message}")
+            }.getOrNull()
+
+            // 재발급된 토큰 추출 (실패시 삭제)
+            val tokenBody = newResponse?.body()?.refreshResponseToGoogleLogin() ?: run {
+                tokenLocalDataSource.removeRefreshToken() // RefreshToken 삭제
+                goToLoginActivity()
+                return@withLock null
+            }
+
+            // 재발급된 토큰 저장 및 새 요청 생성
+            tokenLocalDataSource.saveAccessToken(tokenBody.accessToken)
+            tokenLocalDataSource.saveRefreshToken(tokenBody.refreshToken)
+            response.request.newBuilder()
+                .removeHeader("Authorization")
+                .addHeader("Authorization", "Bearer ${tokenBody.accessToken}")
+                .build()
+        }
+    }
+
+    // 무한 재시도 방지를 위해 재시도 요청 횟수 계산
+    private fun Response.responseCount(): Int {
+        var response: Response? = this
+        var result = 1
+        while (response?.priorResponse.also { response = it } != null) {
+            result++
+        }
+        return result
+    }
+
+    private fun goToLoginActivity() {
+//        val handler = HandlerCompat.createAsync(Looper.getMainLooper())
+//        Intent(context.applicationContext, LoginActivity::class.java).run {
+//            handler.post { context.applicationContext.showToast(context.getString(R.string.token_out_dated)) }
+//            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+//            context.startActivity(this)
+//        }
+    }
+}

--- a/app/src/main/java/org/sopt/and/di/network/AuthAuthenticator.kt
+++ b/app/src/main/java/org/sopt/and/di/network/AuthAuthenticator.kt
@@ -57,7 +57,7 @@ class AuthAuthenticator @Inject constructor(
             }.getOrNull()
 
             // 재발급된 토큰 추출 (실패시 삭제)
-            val tokenBody = newResponse?.body()?.refreshResponseToGoogleLogin() ?: run {
+            val tokenBody = newResponse?.body()?.refreshResponseToAuthToken() ?: run {
                 deleteUserRefreshTokenUseCase() // RefreshToken 삭제
                 goToLoginActivity()
                 return@withLock null

--- a/app/src/main/java/org/sopt/and/di/network/AuthAuthenticator.kt
+++ b/app/src/main/java/org/sopt/and/di/network/AuthAuthenticator.kt
@@ -11,12 +11,16 @@ import okhttp3.Route
 import org.sopt.and.data.api.AuthApi
 import org.sopt.and.data.model.request.RefreshRequest
 import org.sopt.and.data.remote.datasource.local.TokenLocalDataSource
+import org.sopt.and.domain.usecase.DeleteUserRefreshTokenUseCase
+import org.sopt.and.domain.usecase.UpdateUserRefreshTokenUseCase
 import timber.log.Timber
 import javax.inject.Inject
 
 class AuthAuthenticator @Inject constructor(
     private val context: Context,
     private val tokenLocalDataSource: TokenLocalDataSource,
+    private val updateUserRefreshTokenUseCase: UpdateUserRefreshTokenUseCase,
+    private val deleteUserRefreshTokenUseCase: DeleteUserRefreshTokenUseCase,
     private val authApi: AuthApi,
     private val maxRetry: Int = 5,
 ) : Authenticator {
@@ -30,7 +34,7 @@ class AuthAuthenticator @Inject constructor(
             Timber.e("토큰 재발급 요청 시도")
             // 지정 최대 시도 횟수를 초과하면 로그인 화면으로 이동
             if (response.responseCount() > maxRetry) {
-                tokenLocalDataSource.removeRefreshToken() // RefreshToken 삭제
+                deleteUserRefreshTokenUseCase() // RefreshToken 삭제
                 goToLoginActivity()
                 return@withLock null
             }
@@ -44,7 +48,7 @@ class AuthAuthenticator @Inject constructor(
             }.onSuccess {
                 if (!it.isSuccessful) {
                     Timber.e("Refresh API HTTP Exception : $it")
-                    tokenLocalDataSource.removeRefreshToken() // RefreshToken 삭제
+                    deleteUserRefreshTokenUseCase() // RefreshToken 삭제
                     goToLoginActivity() // 로그인 화면으로 이동
                     return@withLock null
                 }
@@ -54,14 +58,13 @@ class AuthAuthenticator @Inject constructor(
 
             // 재발급된 토큰 추출 (실패시 삭제)
             val tokenBody = newResponse?.body()?.refreshResponseToGoogleLogin() ?: run {
-                tokenLocalDataSource.removeRefreshToken() // RefreshToken 삭제
+                deleteUserRefreshTokenUseCase() // RefreshToken 삭제
                 goToLoginActivity()
                 return@withLock null
             }
 
             // 재발급된 토큰 저장 및 새 요청 생성
-            tokenLocalDataSource.saveAccessToken(tokenBody.accessToken)
-            tokenLocalDataSource.saveRefreshToken(tokenBody.refreshToken)
+            updateUserRefreshTokenUseCase(tokenBody)
             response.request.newBuilder()
                 .removeHeader("Authorization")
                 .addHeader("Authorization", "Bearer ${tokenBody.accessToken}")

--- a/app/src/main/java/org/sopt/and/di/network/AuthAuthenticator.kt
+++ b/app/src/main/java/org/sopt/and/di/network/AuthAuthenticator.kt
@@ -8,7 +8,7 @@ import okhttp3.Authenticator
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.Route
-import org.sopt.and.data.api.AuthApi
+import org.sopt.and.data.api.ReissueTokenApi
 import org.sopt.and.data.model.request.RefreshRequest
 import org.sopt.and.data.remote.datasource.local.TokenLocalDataSource
 import org.sopt.and.domain.usecase.DeleteUserRefreshTokenUseCase
@@ -21,8 +21,7 @@ class AuthAuthenticator @Inject constructor(
     private val tokenLocalDataSource: TokenLocalDataSource,
     private val updateUserRefreshTokenUseCase: UpdateUserRefreshTokenUseCase,
     private val deleteUserRefreshTokenUseCase: DeleteUserRefreshTokenUseCase,
-    private val authApi: AuthApi,
-    private val maxRetry: Int = 5,
+    private val reissueTokenApi: ReissueTokenApi,
 ) : Authenticator {
     private val mutex = Mutex()
 
@@ -30,21 +29,12 @@ class AuthAuthenticator @Inject constructor(
     // 액세스 토큰이 만료되면 자동으로 액세스 토큰을 재발급 요청 하는 함수
     override fun authenticate(route: Route?, response: Response): Request? = runBlocking {
         mutex.withLock {
-            Timber.e("HTTP 401 response : $response")
-            Timber.e("토큰 재발급 요청 시도")
-            // 지정 최대 시도 횟수를 초과하면 로그인 화면으로 이동
-            if (response.responseCount() > maxRetry) {
-                deleteUserRefreshTokenUseCase() // RefreshToken 삭제
-                goToLoginActivity()
-                return@withLock null
-            }
-
             // 현재 리프레시 토큰 가져오기
             val currentRefreshToken = tokenLocalDataSource.getRefreshToken() ?: ""
 
             // 토큰 재발급 API 호출
             val newResponse = runCatching {
-                authApi.postRefresh(RefreshRequest(currentRefreshToken))
+                reissueTokenApi.postRefresh(RefreshRequest(currentRefreshToken))
             }.onSuccess {
                 if (!it.isSuccessful) {
                     Timber.e("Refresh API HTTP Exception : $it")
@@ -70,16 +60,6 @@ class AuthAuthenticator @Inject constructor(
                 .addHeader("Authorization", "Bearer ${tokenBody.accessToken}")
                 .build()
         }
-    }
-
-    // 무한 재시도 방지를 위해 재시도 요청 횟수 계산
-    private fun Response.responseCount(): Int {
-        var response: Response? = this
-        var result = 1
-        while (response?.priorResponse.also { response = it } != null) {
-            result++
-        }
-        return result
     }
 
     private fun goToLoginActivity() {

--- a/app/src/main/java/org/sopt/and/di/network/NetworkModule.kt
+++ b/app/src/main/java/org/sopt/and/di/network/NetworkModule.kt
@@ -17,24 +17,21 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.logging.HttpLoggingInterceptor
 import org.sopt.and.BuildConfig
-import org.sopt.and.data.api.AuthApi
+import org.sopt.and.data.api.ReissueTokenApi
 import org.sopt.and.data.interceptor.AccessTokenInterceptor
 import org.sopt.and.data.remote.datasource.local.TokenLocalDataSource
 import org.sopt.and.domain.usecase.DeleteUserRefreshTokenUseCase
 import org.sopt.and.domain.usecase.UpdateUserRefreshTokenUseCase
 import org.sopt.and.utils.TokenManager
+import org.sopt.and.utils.qualifier.AuthNotRequired
+import org.sopt.and.utils.qualifier.AuthRequired
 import retrofit2.Retrofit
 import java.util.concurrent.TimeUnit
-import javax.inject.Qualifier
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
-
-    @Qualifier
-    @Retention(AnnotationRetention.BINARY)
-    annotation class MainServer
 
     @Provides
     @Singleton
@@ -81,6 +78,7 @@ object NetworkModule {
 
     // 만료된 액세스 토큰이 포함된 요청이 서버에서 거부되었을 때(HTTP 401 응답)
     // 자동으로 토큰을 재발급받는 역할을 수행
+    @AuthRequired
     @Provides
     @Singleton
     fun provideRefreshInterceptor(
@@ -88,16 +86,17 @@ object NetworkModule {
         tokenLocalDataSource: TokenLocalDataSource,
         updateUserRefreshTokenUseCase: UpdateUserRefreshTokenUseCase,
         deleteUserRefreshTokenUseCase: DeleteUserRefreshTokenUseCase,
-        authApi: AuthApi,
-    ): AuthAuthenticator = AuthAuthenticator(context, tokenLocalDataSource, updateUserRefreshTokenUseCase, deleteUserRefreshTokenUseCase, authApi)
+        @AuthRequired reissueTokenApi: ReissueTokenApi
+    ): Authenticator = AuthAuthenticator(context, tokenLocalDataSource, updateUserRefreshTokenUseCase, deleteUserRefreshTokenUseCase, reissueTokenApi)
 
+    @AuthRequired
     @Provides
     @Singleton
-    fun provideOKHttpClient(
+    fun provideAuthOKHttpClient(
         httpLoggingInterceptor: HttpLoggingInterceptor,
         accessTokenInterceptor: AccessTokenInterceptor,
         authInterceptor: Interceptor,
-        refreshInterceptor: Authenticator,
+        @AuthRequired refreshInterceptor: Authenticator,
     ): OkHttpClient =
         OkHttpClient.Builder().apply {
             connectTimeout(30, TimeUnit.SECONDS)
@@ -109,12 +108,22 @@ object NetworkModule {
             authenticator(refreshInterceptor)
         }.build()
 
+    @AuthNotRequired
+    @Singleton
+    @Provides
+    fun provideOkHttpClientAuthNotRequired(
+        httpLoggingInterceptor: Interceptor,
+    ): OkHttpClient = OkHttpClient.Builder()
+        .addInterceptor(httpLoggingInterceptor)
+        .build()
+
+    @AuthRequired
     @ExperimentalSerializationApi
-    @MainServer
     @Provides
     @Singleton
-    fun provideMainRetrofit(
-        okHttpClient: OkHttpClient, json: Json
+    fun provideAuthRetrofit(
+        @AuthRequired okHttpClient: OkHttpClient,
+        json: Json,
     ): Retrofit {
         return Retrofit.Builder()
             .baseUrl(BuildConfig.BASE_SERVER_URL)
@@ -122,5 +131,18 @@ object NetworkModule {
             .addConverterFactory(json.asConverterFactory((requireNotNull("application/json".toMediaTypeOrNull()))))
             .build()
     }
+
+
+    @AuthNotRequired
+    @Singleton
+    @Provides
+    fun provideRetrofitAuthNotRequired(
+        @AuthNotRequired okHttpClient: OkHttpClient,
+        json: Json,
+    ): Retrofit = Retrofit.Builder()
+        .baseUrl(BuildConfig.BASE_SERVER_URL)
+        .client(okHttpClient)
+        .addConverterFactory(json.asConverterFactory((requireNotNull("application/json".toMediaTypeOrNull()))))
+        .build()
 
 }

--- a/app/src/main/java/org/sopt/and/di/network/NetworkModule.kt
+++ b/app/src/main/java/org/sopt/and/di/network/NetworkModule.kt
@@ -1,17 +1,27 @@
 package org.sopt.and.di.network
 
+import android.content.Context
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
+import okhttp3.Authenticator
+import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
+import okhttp3.Request
 import okhttp3.logging.HttpLoggingInterceptor
 import org.sopt.and.BuildConfig
+import org.sopt.and.data.api.AuthApi
 import org.sopt.and.data.interceptor.AccessTokenInterceptor
+import org.sopt.and.data.remote.datasource.local.TokenLocalDataSource
+import org.sopt.and.domain.usecase.DeleteUserRefreshTokenUseCase
+import org.sopt.and.domain.usecase.UpdateUserRefreshTokenUseCase
 import org.sopt.and.utils.TokenManager
 import retrofit2.Retrofit
 import java.util.concurrent.TimeUnit
@@ -44,17 +54,50 @@ object NetworkModule {
         }
     }
 
+    // 기존 DataSource (과제 였던 토큰 저장용 - 구글로그인 X)
     @Provides
     @Singleton
     fun provideTokenInterceptor(tokenManager: TokenManager): AccessTokenInterceptor {
         return AccessTokenInterceptor(tokenManager)
     }
 
+    // Retrofit으로 네트워크 요청할 때 uthorization 헤더를 자동으로 추가하는 함수
+    // 사용자의 액세스 토큰을 로컬에서 가져와 요청에 포함한다.
+    @Provides
+    @Singleton
+    fun provideAuthInterceptor(
+        tokenLocalDataSource: TokenLocalDataSource,
+    ): Interceptor {
+        return Interceptor { chain: Interceptor.Chain ->
+            runBlocking {
+                val accessToken = tokenLocalDataSource.getAccessToken() ?: ""
+                val newRequest: Request = chain.request().newBuilder()
+                    .addHeader("Authorization", "Bearer $accessToken")
+                    .build()
+                chain.proceed(newRequest)
+            }
+        }
+    }
+
+    // 만료된 액세스 토큰이 포함된 요청이 서버에서 거부되었을 때(HTTP 401 응답)
+    // 자동으로 토큰을 재발급받는 역할을 수행
+    @Provides
+    @Singleton
+    fun provideRefreshInterceptor(
+        @ApplicationContext context: Context,
+        tokenLocalDataSource: TokenLocalDataSource,
+        updateUserRefreshTokenUseCase: UpdateUserRefreshTokenUseCase,
+        deleteUserRefreshTokenUseCase: DeleteUserRefreshTokenUseCase,
+        authApi: AuthApi,
+    ): AuthAuthenticator = AuthAuthenticator(context, tokenLocalDataSource, updateUserRefreshTokenUseCase, deleteUserRefreshTokenUseCase, authApi)
+
     @Provides
     @Singleton
     fun provideOKHttpClient(
         httpLoggingInterceptor: HttpLoggingInterceptor,
-        accessTokenInterceptor: AccessTokenInterceptor
+        accessTokenInterceptor: AccessTokenInterceptor,
+        authInterceptor: Interceptor,
+        refreshInterceptor: Authenticator,
     ): OkHttpClient =
         OkHttpClient.Builder().apply {
             connectTimeout(30, TimeUnit.SECONDS)
@@ -62,6 +105,8 @@ object NetworkModule {
             writeTimeout(30, TimeUnit.SECONDS)
             if(BuildConfig.DEBUG) addInterceptor(httpLoggingInterceptor)
             addInterceptor(accessTokenInterceptor)
+            addInterceptor(authInterceptor)
+            authenticator(refreshInterceptor)
         }.build()
 
     @ExperimentalSerializationApi

--- a/app/src/main/java/org/sopt/and/di/repository/GoogleTokenRepositoryModule.kt
+++ b/app/src/main/java/org/sopt/and/di/repository/GoogleTokenRepositoryModule.kt
@@ -10,7 +10,7 @@ import org.sopt.and.domain.repository.GoogleTokenRepository
 
 @Module
 @InstallIn(ActivityComponent::class) // ActivityScoped로 관리, 구글로그인 전용 DI
-abstract class TokenRepositoryModule {
+abstract class GoogleTokenRepositoryModule {
     // GoogleSignInRepository 추가
     @Binds
     @ActivityScoped

--- a/app/src/main/java/org/sopt/and/di/repository/RepositoryModule.kt
+++ b/app/src/main/java/org/sopt/and/di/repository/RepositoryModule.kt
@@ -6,8 +6,10 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import org.sopt.and.data.remote.repository.LocalHomeImageRepositoryImpl
 import org.sopt.and.data.remote.repository.AuthRepositoryImpl
+import org.sopt.and.data.remote.repository.AuthTokenRepositoryImpl
 import org.sopt.and.data.remote.repository.UserRepositoryImpl
 import org.sopt.and.domain.repository.AuthRepository
+import org.sopt.and.domain.repository.AuthTokenRepository
 import org.sopt.and.domain.repository.UserRepository
 import org.sopt.and.domain.repository.LocalHomeImageRepository
 import javax.inject.Singleton
@@ -15,6 +17,12 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class RepositoryModule {
+    @Binds
+    @Singleton
+    abstract fun bindsAuthTokenRepository(
+        authTokenRepositoryImpl: AuthTokenRepositoryImpl
+    ): AuthTokenRepository
+
     @Binds
     @Singleton
     abstract fun bindsAuthRepository(

--- a/app/src/main/java/org/sopt/and/di/repository/TokenRepositoryModule.kt
+++ b/app/src/main/java/org/sopt/and/di/repository/TokenRepositoryModule.kt
@@ -5,8 +5,8 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ActivityComponent
 import dagger.hilt.android.scopes.ActivityScoped
-import org.sopt.and.data.remote.repository.GoogleSignInRepositoryImpl
-import org.sopt.and.domain.repository.TokenRepository
+import org.sopt.and.data.remote.repository.GoogleTokenRepositoryImpl
+import org.sopt.and.domain.repository.GoogleTokenRepository
 
 @Module
 @InstallIn(ActivityComponent::class) // ActivityScoped로 관리, 구글로그인 전용 DI
@@ -15,7 +15,7 @@ abstract class TokenRepositoryModule {
     @Binds
     @ActivityScoped
     abstract fun bindsGoogleSignInRepository(
-        googleSignInRepositoryImpl: GoogleSignInRepositoryImpl
-    ): TokenRepository
+        googleSignInRepositoryImpl: GoogleTokenRepositoryImpl
+    ): GoogleTokenRepository
 
 }

--- a/app/src/main/java/org/sopt/and/di/source/LocalDataSourceModule.kt
+++ b/app/src/main/java/org/sopt/and/di/source/LocalDataSourceModule.kt
@@ -1,0 +1,25 @@
+package org.sopt.and.di.source
+
+import android.content.Context
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
+import org.sopt.and.data.remote.datasource.local.TokenLocalDataSource
+import org.sopt.and.di.CoroutineModule
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object LocalDataSourceModule {
+    @Provides
+    @Singleton
+    fun provideTokenLocalDataSource(
+        @ApplicationContext applicationContext: Context,
+        @CoroutineModule.IoDispatcher dispatcherIO: CoroutineDispatcher
+    ): TokenLocalDataSource {
+        return TokenLocalDataSource(applicationContext, dispatcherIO)
+    }
+}

--- a/app/src/main/java/org/sopt/and/di/source/RemoteDataSourceModule.kt
+++ b/app/src/main/java/org/sopt/and/di/source/RemoteDataSourceModule.kt
@@ -1,0 +1,31 @@
+package org.sopt.and.di.source
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import org.sopt.and.data.api.AuthApi
+import org.sopt.and.data.api.UserApi
+import org.sopt.and.data.remote.datasource.remote.AuthDataSource
+import org.sopt.and.data.remote.datasource.remote.UserDataSource
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object RemoteDataSourceModule {
+    @Provides
+    @Singleton
+    fun provideAuthRemoteDataSource(
+        authApi: AuthApi
+    ): AuthDataSource  {
+        return AuthDataSource(authApi)
+    }
+
+    @Provides
+    @Singleton
+    fun provideUserDataSource(
+        userApi: UserApi
+    ): UserDataSource {
+        return UserDataSource(userApi)
+    }
+}

--- a/app/src/main/java/org/sopt/and/di/source/RemoteGoogleDataSourceModule.kt
+++ b/app/src/main/java/org/sopt/and/di/source/RemoteGoogleDataSourceModule.kt
@@ -1,4 +1,4 @@
-package org.sopt.and.di
+package org.sopt.and.di.source
 
 import android.content.Context
 import androidx.credentials.CredentialManager
@@ -10,27 +10,34 @@ import dagger.hilt.android.components.ActivityComponent
 import dagger.hilt.android.qualifiers.ActivityContext
 import dagger.hilt.android.scopes.ActivityScoped
 import org.sopt.and.BuildConfig
+import org.sopt.and.data.remote.datasource.remote.TokenRemoteDataSource
 
 @Module
 @InstallIn(ActivityComponent::class)
-object GoogleAuthModule {
-    // Google ID 옵션 제공 함수
+object RemoteGoogleDataSourceModule {
     @Provides
     @ActivityScoped
     fun provideGoogleIdOptions(): GetGoogleIdOption {
         return GetGoogleIdOption.Builder()
             .setFilterByAuthorizedAccounts(false)
-            .setAutoSelectEnabled(false) // 재방문 사용자의 자동 로그인 사용 설정
-            .setServerClientId(BuildConfig.GOOGLE_CLIENT_ID) // 클라이언트 ID 설정
+            .setAutoSelectEnabled(false)
+            .setServerClientId(BuildConfig.GOOGLE_CLIENT_ID)
             .build()
     }
 
-    // Google의 최신 인증 API를 사용하는 객체
     @Provides
     @ActivityScoped
-    fun provideCredentialManager(
-        @ActivityContext context: Context): CredentialManager {
+    fun provideCredentialManager(@ActivityContext context: Context): CredentialManager {
         return CredentialManager.create(context)
     }
 
+    @Provides
+    @ActivityScoped
+    fun provideTokenRemoteDataSource(
+        credentialManager: CredentialManager,
+        googleIdOption: GetGoogleIdOption,
+        @ActivityContext context: Context
+    ): TokenRemoteDataSource {
+        return TokenRemoteDataSource(credentialManager, googleIdOption, context)
+    }
 }

--- a/app/src/main/java/org/sopt/and/domain/model/AuthToken.kt
+++ b/app/src/main/java/org/sopt/and/domain/model/AuthToken.kt
@@ -1,0 +1,6 @@
+package org.sopt.and.domain.model
+
+data class AuthToken(
+    val accessToken: String,
+    val refreshToken: String,
+)

--- a/app/src/main/java/org/sopt/and/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/org/sopt/and/domain/repository/AuthRepository.kt
@@ -1,5 +1,6 @@
 package org.sopt.and.domain.repository
 
+import org.sopt.and.domain.model.AuthToken
 import org.sopt.and.domain.model.auth.LoginUserEntity
 import org.sopt.and.domain.model.auth.RegisterUserEntity
 import org.sopt.and.domain.model.auth.UserIdEntity
@@ -7,8 +8,7 @@ import org.sopt.and.domain.model.auth.UserTokenEntity
 import org.sopt.and.utils.SocialType
 
 interface AuthRepository {
-    suspend fun postLogin(socialType: SocialType, idToken: String): Result<Unit> // 구글 로그인
-    suspend fun postRefresh(refreshToken: String): Result<Unit> // refresh Token
+    suspend fun postLogin(socialType: SocialType, idToken: String): AuthToken // 구글 로그인
 
     suspend fun registerUser(userEntity: RegisterUserEntity): Result<UserIdEntity>
     suspend fun loginUser(loginUserEntity: LoginUserEntity): Result<UserTokenEntity>

--- a/app/src/main/java/org/sopt/and/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/org/sopt/and/domain/repository/AuthRepository.kt
@@ -4,8 +4,13 @@ import org.sopt.and.domain.model.auth.LoginUserEntity
 import org.sopt.and.domain.model.auth.RegisterUserEntity
 import org.sopt.and.domain.model.auth.UserIdEntity
 import org.sopt.and.domain.model.auth.UserTokenEntity
+import org.sopt.and.utils.SocialType
 
 interface AuthRepository {
+    suspend fun postLogin(socialType: SocialType, idToken: String): Result<Unit> // 구글 로그인
+    suspend fun postRefresh(refreshToken: String): Result<Unit> // refresh Token
+
     suspend fun registerUser(userEntity: RegisterUserEntity): Result<UserIdEntity>
     suspend fun loginUser(loginUserEntity: LoginUserEntity): Result<UserTokenEntity>
+
 }

--- a/app/src/main/java/org/sopt/and/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/org/sopt/and/domain/repository/AuthRepository.kt
@@ -8,7 +8,7 @@ import org.sopt.and.domain.model.auth.UserTokenEntity
 import org.sopt.and.utils.SocialType
 
 interface AuthRepository {
-    suspend fun postLogin(socialType: SocialType, idToken: String): AuthToken // 구글 로그인
+    suspend fun postLogin(socialType: SocialType, idToken: String): Result<Unit> // 구글 로그인
 
     suspend fun registerUser(userEntity: RegisterUserEntity): Result<UserIdEntity>
     suspend fun loginUser(loginUserEntity: LoginUserEntity): Result<UserTokenEntity>

--- a/app/src/main/java/org/sopt/and/domain/repository/AuthTokenRepository.kt
+++ b/app/src/main/java/org/sopt/and/domain/repository/AuthTokenRepository.kt
@@ -5,5 +5,6 @@ interface AuthTokenRepository {
     suspend fun saveRefreshToken(token: String)
     suspend fun getAccessToken(): String?
     suspend fun getRefreshToken(): String?
+    suspend fun removeAccessToken()
     suspend fun removeRefreshToken()
 }

--- a/app/src/main/java/org/sopt/and/domain/repository/AuthTokenRepository.kt
+++ b/app/src/main/java/org/sopt/and/domain/repository/AuthTokenRepository.kt
@@ -1,0 +1,9 @@
+package org.sopt.and.domain.repository
+
+interface AuthTokenRepository {
+    suspend fun saveAccessToken(token: String)
+    suspend fun saveRefreshToken(token: String)
+    suspend fun getAccessToken(): String?
+    suspend fun getRefreshToken(): String?
+    suspend fun removeRefreshToken()
+}

--- a/app/src/main/java/org/sopt/and/domain/repository/GoogleTokenRepository.kt
+++ b/app/src/main/java/org/sopt/and/domain/repository/GoogleTokenRepository.kt
@@ -2,6 +2,6 @@ package org.sopt.and.domain.repository
 
 import androidx.credentials.Credential
 
-interface TokenRepository {
+interface GoogleTokenRepository {
     suspend fun signIn(): Result<Credential>
 }

--- a/app/src/main/java/org/sopt/and/domain/usecase/DeleteUserRefreshTokenUseCase‎.kt
+++ b/app/src/main/java/org/sopt/and/domain/usecase/DeleteUserRefreshTokenUseCase‎.kt
@@ -1,0 +1,13 @@
+package org.sopt.and.domain.usecase
+
+import org.sopt.and.domain.repository.AuthTokenRepository
+import javax.inject.Inject
+
+class DeleteUserRefreshTokenUseCase @Inject constructor(
+    private val authTokenRepository: AuthTokenRepository
+) {
+    suspend operator fun invoke() {
+        authTokenRepository.removeAccessToken()
+        authTokenRepository.removeRefreshToken()
+    }
+}

--- a/app/src/main/java/org/sopt/and/domain/usecase/UpdateUserRefreshTokenUseCase.kt
+++ b/app/src/main/java/org/sopt/and/domain/usecase/UpdateUserRefreshTokenUseCase.kt
@@ -1,13 +1,13 @@
 package org.sopt.and.domain.usecase
 
-import org.sopt.and.data.model.response.GoogleLoginResponse
+import org.sopt.and.domain.model.AuthToken
 import org.sopt.and.domain.repository.AuthTokenRepository
 import javax.inject.Inject
 
 class UpdateUserRefreshTokenUseCase @Inject constructor(
     private val authTokenRepository: AuthTokenRepository,
 ) {
-    suspend operator fun invoke(refreshBody: GoogleLoginResponse) {
+    suspend operator fun invoke(refreshBody: AuthToken) {
         authTokenRepository.saveAccessToken(refreshBody.accessToken)
         authTokenRepository.saveRefreshToken(refreshBody.refreshToken)
     }

--- a/app/src/main/java/org/sopt/and/domain/usecase/UpdateUserRefreshTokenUseCase.kt
+++ b/app/src/main/java/org/sopt/and/domain/usecase/UpdateUserRefreshTokenUseCase.kt
@@ -1,0 +1,14 @@
+package org.sopt.and.domain.usecase
+
+import org.sopt.and.data.model.response.GoogleLoginResponse
+import org.sopt.and.domain.repository.AuthTokenRepository
+import javax.inject.Inject
+
+class UpdateUserRefreshTokenUseCase @Inject constructor(
+    private val authTokenRepository: AuthTokenRepository,
+) {
+    suspend operator fun invoke(refreshBody: GoogleLoginResponse) {
+        authTokenRepository.saveAccessToken(refreshBody.accessToken)
+        authTokenRepository.saveRefreshToken(refreshBody.refreshToken)
+    }
+}

--- a/app/src/main/java/org/sopt/and/presentation/ui/main/MainActivity.kt
+++ b/app/src/main/java/org/sopt/and/presentation/ui/main/MainActivity.kt
@@ -6,14 +6,14 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import dagger.hilt.android.AndroidEntryPoint
 import org.sopt.and.core.designsystem.theme.ANDANDROIDTheme
-import org.sopt.and.domain.repository.TokenRepository
+import org.sopt.and.domain.repository.GoogleTokenRepository
 import org.sopt.and.presentation.ui.main.navigation.rememberMainNavigator
 import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     @Inject
-    lateinit var googleSignInRepository: TokenRepository
+    lateinit var googleSignInRepository: GoogleTokenRepository
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/org/sopt/and/presentation/ui/main/MainScreen.kt
+++ b/app/src/main/java/org/sopt/and/presentation/ui/main/MainScreen.kt
@@ -24,7 +24,7 @@ import org.sopt.and.core.designsystem.theme.Black
 import org.sopt.and.core.designsystem.theme.Gray100
 import org.sopt.and.core.designsystem.theme.White
 import org.sopt.and.core.util.NoRippleInteraction
-import org.sopt.and.domain.repository.TokenRepository
+import org.sopt.and.domain.repository.GoogleTokenRepository
 import org.sopt.and.presentation.ui.home.homeNavGraph
 import org.sopt.and.presentation.ui.main.navigation.MainBottomNavigationType
 import org.sopt.and.presentation.ui.main.navigation.MainNavigator
@@ -36,7 +36,7 @@ import org.sopt.and.presentation.ui.signup.navigation.signUpGraph
 @Composable
 fun MainScreen(
     navigator: MainNavigator,
-    googleSignInRepository: TokenRepository
+    googleSignInRepository: GoogleTokenRepository
 ) {
     Scaffold(
         bottomBar = {

--- a/app/src/main/java/org/sopt/and/presentation/ui/signin/SignInNavigation.kt
+++ b/app/src/main/java/org/sopt/and/presentation/ui/signin/SignInNavigation.kt
@@ -5,7 +5,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import kotlinx.serialization.Serializable
-import org.sopt.and.domain.repository.TokenRepository
+import org.sopt.and.domain.repository.GoogleTokenRepository
 
 fun NavController.navigateSignIn(navOptions: NavOptions? = null) {
     navigate(
@@ -17,7 +17,7 @@ fun NavController.navigateSignIn(navOptions: NavOptions? = null) {
 fun NavGraphBuilder.signInGraph(
     navigateToRegister: () -> Unit,
     navigateToHome: () -> Unit,
-    googleSignInRepository: TokenRepository
+    googleSignInRepository: GoogleTokenRepository
 ) {
     composable(SignInRoute.LOGIN_ROUTE) {
         SignInRoute(

--- a/app/src/main/java/org/sopt/and/presentation/ui/signin/SignInRoute.kt
+++ b/app/src/main/java/org/sopt/and/presentation/ui/signin/SignInRoute.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import org.sopt.and.domain.repository.TokenRepository
+import org.sopt.and.domain.repository.GoogleTokenRepository
 import org.sopt.and.presentation.utils.contract.SignInContract
 import org.sopt.and.presentation.viewmodel.GoogleSignInViewModel
 import org.sopt.and.presentation.viewmodel.SignInViewModel
@@ -22,7 +22,7 @@ import org.sopt.and.utils.showToastMessage
 fun SignInRoute (
     navigateSignUp: () -> Unit,
     navigateHome: () -> Unit,
-    googleSignInRepository: TokenRepository,
+    googleSignInRepository: GoogleTokenRepository,
     viewModel: SignInViewModel = hiltViewModel(),
     googleSignInViewModel: GoogleSignInViewModel = hiltViewModel() // GoogleSignInViewModel 추가
 ) {

--- a/app/src/main/java/org/sopt/and/presentation/viewmodel/GoogleSignInViewModel.kt
+++ b/app/src/main/java/org/sopt/and/presentation/viewmodel/GoogleSignInViewModel.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.viewmodel.container
-import org.sopt.and.domain.repository.TokenRepository
+import org.sopt.and.domain.repository.GoogleTokenRepository
 import org.sopt.and.presentation.utils.contract.SignInContract
 import javax.inject.Inject
 
@@ -51,7 +51,7 @@ class GoogleSignInViewModel @Inject constructor(
 //    }
 
     // 구글 로그인 임시 액티비티 실행되도록 하는 목적의 함수
-    fun googleLogin(googleSignInRepository: TokenRepository) {
+    fun googleLogin(googleSignInRepository: GoogleTokenRepository) {
         viewModelScope.launch {
             googleSignInRepository.signIn()
         }

--- a/app/src/main/java/org/sopt/and/utils/SocialType.kt
+++ b/app/src/main/java/org/sopt/and/utils/SocialType.kt
@@ -1,0 +1,5 @@
+package org.sopt.and.utils
+
+enum class SocialType {
+    GOOGLE, APPLE
+}

--- a/app/src/main/java/org/sopt/and/utils/qualifier/InjectQualifier.kt
+++ b/app/src/main/java/org/sopt/and/utils/qualifier/InjectQualifier.kt
@@ -1,0 +1,11 @@
+package org.sopt.and.utils.qualifier
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class AuthRequired
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class AuthNotRequired


### PR DESCRIPTION
## Related issue 🛠
- closed #9

## 데이터 흐름 설계 ✏️
### 토큰을 Request Header에 담는 과정
<strong>1. TokenRemoteDataSource에서 Google Cloud Console에서 IDToken 받아옴 </strong>

<strong>2. 이 IDToken과 Google (Enum 타입)을 DTO에 담아서 서버에 POST 요청 보냄 </strong>

<strong>3. 2번 요청을 보내는 동시에 서버가 Response로 반환한 AT, RT를 AuthRepositoryImpl에서 TokenLocalDataSource에 저장  </strong>
- (동시에 같은 함수에서 진행) -> 이렇게 진행하는게 맞는지 모르겠다. (2f93c86 ~ 6465bd5 커밋)

<strong>4. tokenLocalDataSource에서 저장된 AT를 꺼내 Retrofit 헤더에 AT 담음 (NetworkModule) </strong>
<hr></hr>

### AT 만료시 RT로 토큰 갱신
<strong>1. AuthAuthenticator를 Retrofit에 authenticator로 등록 (NetworkModule) </strong>
- 서버로부터 HTTP 401 응답이 반환되면 AuthAuthenticator가 호출됨

<strong>2. AuthAuthenticator에서 RT를 사용해 새 토큰 발급 요청</strong>
- authApi.postRefresh를 호출하여 서버에 Refresh Token을 전송, 서버로부터 새 AT, RT 받음

<strong>3. 새로운 AT, RT를 TokenLocalDataSource에 저장</strong>
- updateUserRefreshTokenUseCase를 통해 새 토큰을 저장 (AT, RT)

<strong>4. 새 AT로 기존 요청 재시도</strong>

## Work Description ✏️
- 작업 내용 및 진행 순서

<strong>1. 토큰 발급 및 갱신 관련 Request/Response DTO 추가 </strong>

<strong>2. 서버와의 통신을 위한 토큰 관련 API 함수 구현</strong>

<strong>3. AuthAuthenticator 구현</strong>  
- OkHttp의 Authenticator를 활용해 토큰 만료 시 자동으로 재발급 요청  

<strong>4. Auth Token 관련 파일 추가</strong>  
- Access Token 및 Refresh Token의 생성, 저장, 조회, 삭제를 담당하는 클래스 구현  

<strong>5. Coroutine Module 추가</strong>  
- Coroutine 사용을 위한 Dispatcher 주입 설정  

<strong>6. LocalDataSourceModule 추가</strong>  
- 로컬 데이터 관리를 위한 DI 모듈 정의  
- Auth Token 저장소와 관련된 Local DataSource 객체를 주입하도록 설정  

<strong>7. GoogleTokenRepositoryModule 추가</strong>  
- 구글 서버와 통신하는 리포지토리를 위한 모듈 정의  
- Google Token 관련 서버 요청을 처리하는 로직 포함  

<strong>8. RemoteDataSourceModule 추가</strong>  
- Remote DataSource를 관리하는 DI 모듈 추가  

<strong>9. RepositoryModule에 AuthTokenRepository 추가</strong>  
- 토큰 관련 데이터를 처리하는 로직을 통합  

<strong>10. GoogleAuthModule과 RemoteGoogleDataSourceModule 통합</strong>  
- 구글 서버와의 통신을 위한 기존 모듈과 새로운 모듈을 통합  

<strong>11. removeAccessToken() 함수 추가</strong>  

<strong>12. 토큰 삭제 및 업데이트 로직 UseCase로 분리</strong>  
- Access Token 및 Refresh Token의 삭제와 갱신 로직을 UseCase로 분리  

<strong>13. NetworkModule에 Interceptor 추가</strong>  
- OkHttp 클라이언트에 AuthInterceptor와 RefreshInterceptor 추가  
- 네트워크 요청마다 자동으로 Authorization 헤더 추가 및 만료 시 재발급 로직 적용  

<strong>14. 서버에서 Response로 보낸 AT, RT 토큰 저장하는 로직 추가</strong>  
- 서버가 Response로 반환한 AT, RT를 AuthRepositoryImpl에서 TokenLocalDataSource에 저장 (같은 함수 블록)
- Data Layer의 reponseDto 그대로 진행하던 것을 Domain Layer의 모델로 수정 
